### PR TITLE
Pin Docker image Python version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+# Pin Python version below 3.12.0. aiohttp is built from source for Python 3.12 and that failed.
+# Regular review of issue scheduled in https://www.pivotaltracker.com/n/projects/2147543#
+CLOUDFIT_BASE_NAME:=python
+CLOUDFIT_BASE_LABEL:=3.11
+
 # Disable type checking in this repo, since there are no type annotations
 MS_DOCKER_MYPY:=FALSE
 


### PR DESCRIPTION
# Details
The Python 3.12 Docker image resulted in aiohttp building from source and that failed.

Issue was already reported in https://github.com/aio-libs/aiohttp/issues/7646

# Pivotal Story
Story URL:

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] Added bbc/rd-apmm-cloudfit team as a reviewer
- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
